### PR TITLE
fix: always write findings.json for artifact upload

### DIFF
--- a/.github/workflows/scheduled-scan.yml
+++ b/.github/workflows/scheduled-scan.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        run: python -m scanner.main --regions ap-south-1,us-east-1 --slack
+        run: python -m scanner.main --regions ap-south-1,us-east-1 --slack --output findings.json
 
       - name: Upload findings
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What does this PR do?

<!-- One paragraph summary. Link the issue it resolves if applicable. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature / scanner module
- [ ] Refactor / tech debt
- [ ] Docs / ADR
- [ ] CI/CD / infra

## Changes

<!-- Bullet list of the key files changed and why. -->

-
-

## Testing

- [ ] `pytest tests/` passes locally (`pytest --cov=scanner --cov-fail-under=85`)
- [ ] `flake8 scanner notifier db` clean
- [ ] `bandit -r scanner notifier` clean
- [ ] Trivy scan shows no new CRITICAL/HIGH CVEs (CI enforces this)
- [ ] If helm templates changed: `helm template cloudsweep ./helm/cloudsweep` renders without error

## For scanner changes

- [ ] Tested against mock findings (`USE_MOCK_FINDINGS=true`)
- [ ] Tested against real AWS (or noted why not)
- [ ] Pricing logic verified against AWS pricing page

## Screenshots / output (if relevant)

<!-- Grafana dashboard, Slack message, scan output, etc. -->

## Checklist

- [ ] No credentials, API keys, or connection strings in committed files
- [ ] No `print()` statements left in production code (use `click.echo` or logging)
- [ ] New scripts are `chmod +x` and have a usage comment at the top
